### PR TITLE
fix(nav): single navigator per layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
 // app/_layout.tsx     ← raíz de la carpeta app
-import { Slot, useRouter, useSegments, Stack } from "expo-router";
+import { useRouter, useSegments, Stack } from "expo-router";
 // Cargar estilos web globales (procesado por el bundler web de Expo, no por Babel)
 import "./global.css";
 import tw from "@/lib/tw";
@@ -28,7 +28,8 @@ function RootNavigationGate() {
     }
   }, [segments, router, session, initializing]);
 
-  return <Slot />;
+  // Effect-only gate to redirect based on auth; do not render another navigator here.
+  return null;
 }
 
 export default function RootLayout() {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc -p . --noEmit",
     "build:web": "expo export --platform web --dump-sourcemap --non-interactive",
+    "serve:dist": "npx serve dist -l 4173",
     "clean:metro": "node -e \"const fs=require('fs'); const os=require('os'); const p=require('path'); const tmp=os.tmpdir(); ['metro-cache','metro','react-native','@expo'].forEach(d=>{try{fs.rmSync(p.join(tmp,d),{recursive:true,force:true});}catch{}}); console.log('Metro cache cleaned');\""
   },
   "jest": {


### PR DESCRIPTION
Fix web crash 'Another navigator is already registered for this container' by ensuring exactly one navigator per layout.

Changes:
- app/_layout.tsx: remove extra Slot rendering in gate; keep single <Stack/>.
- package.json: add serve:dist to test static build locally.

Manual check:
- Built with 'npm run build:web' and served via 'npm run serve:dist'.