### PR TITLE
feat: onboarding level (B1/B2/C1/C2) + Settings integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ El build web usa placeholders de variables públicas. Para producción, define S
 1. Abrir Supabase → SQL Editor
 2. Pegar contenido de `supabase/schema.sql` → Run
 3. Verificar que se crearon las tablas: `profiles`, `exams`, `attempts`, `attempt_answers`
+4. Nuevo: `profiles.default_level` (B1/B2/C1/C2). Si tu proyecto ya existía, vuelve a ejecutar `supabase/schema.sql` o añade manualmente la columna:
+   ```sql
+   alter table public.profiles add column if not exists default_level text check (default_level in ('B1','B2','C1','C2'));
+   ```
 
 ### 2. Configurar autenticación
 1. Authentication → URL Configuration
@@ -68,3 +72,10 @@ El build web usa placeholders de variables públicas. Para producción, define S
 2. Login con Google
 3. Ejecutar mock → verificar en Progress (nube)
 4. Sin sesión/env → Progress usa intentos locales
+
+## Onboarding de nivel
+
+- Primera vez sin `pref:defaultExamLevel` → se abre `onboarding/level` para elegir B1/B2/C1/C2.
+- Se guarda en AsyncStorage y, si hay sesión Supabase, también en `profiles.default_level`.
+- En Ajustes puedes cambiarlo (abre onboarding en modo edición con confirmación).
+- La generación de exámenes usa este nivel por defecto (fallback: B2).

--- a/app/(auth)/email.tsx
+++ b/app/(auth)/email.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { View, Text, TextInput, Pressable, ActivityIndicator } from 'react-native';
 import * as Linking from 'expo-linking';
 import { useRouter } from 'expo-router';
 import AuthCard from '@/components/AuthCard';
 import { supabase } from '@/lib/supabase';
 import tw from '@/lib/tw';
+import { theme } from '@/lib/theme';
 
 function getRedirectTo(): string {
   // Usa deep link en nativo y URL absoluta en web
@@ -25,6 +26,7 @@ export default function EmailAuthScreen() {
   const [loading, setLoading] = useState(false);
   const [alert, setAlert] = useState<Alert>(null);
   const [isRegister, setIsRegister] = useState(false);
+  const passwordRef = useRef<TextInput | null>(null);
 
   const redirectTo = getRedirectTo();
 
@@ -73,10 +75,10 @@ export default function EmailAuthScreen() {
   };
 
   return (
-    <View style={tw`flex-1 items-center justify-center bg-light px-4`}>
+    <View style={[tw`flex-1 items-center justify-center px-4`, { backgroundColor: theme.colors.bg }]}>
       <AuthCard title="Acceso con email" subtitle="Recibe un enlace o usa contraseña">
         <View style={tw`w-full gap-3`}>
-          <Text style={tw`text-navy`}>Email</Text>
+          <Text style={[tw``, { color: theme.colors.text }]}>Email</Text>
           <TextInput
             inputMode="email"
             autoCapitalize="none"
@@ -85,23 +87,38 @@ export default function EmailAuthScreen() {
             style={tw`rounded-xl border bg-white px-4 py-3`}
             value={email}
             onChangeText={setEmail}
+            returnKeyType={isRegister ? 'next' : 'send'}
+            onSubmitEditing={() => {
+              if (isRegister) {
+                passwordRef.current?.focus();
+              } else if (emailValid) {
+                sendMagicLink();
+              }
+            }}
+            accessibilityLabel="Campo de email"
           />
           {!emailValid && email.length > 0 && (
-            <Text style={tw`text-accent text-xs mt-1`}>Introduce un email válido</Text>
+            <Text style={[tw`text-xs mt-1`, { color: '#dc2626' }]}>Introduce un email válido</Text>
           )}
 
           {isRegister && (
             <>
-              <Text style={tw`text-navy mt-3`}>Contraseña</Text>
+              <Text style={[tw`mt-3`, { color: theme.colors.text }]}>Contraseña</Text>
               <TextInput
                 secureTextEntry
                 placeholder="••••••••"
                 style={tw`rounded-xl border bg-white px-4 py-3`}
                 value={password}
                 onChangeText={setPassword}
+                ref={passwordRef}
+                returnKeyType="done"
+                onSubmitEditing={() => {
+                  if (!passwordError && emailValid && !loading) submitPasswordFlow();
+                }}
+                accessibilityLabel="Campo de contraseña"
               />
               {!!passwordError && (
-                <Text style={tw`text-accent text-xs mt-1`}>{passwordError}</Text>
+                <Text style={[tw`text-xs mt-1`, { color: '#dc2626' }]}>{passwordError}</Text>
               )}
             </>
           )}
@@ -109,7 +126,12 @@ export default function EmailAuthScreen() {
           <Pressable
             disabled={loading || !emailValid}
             onPress={sendMagicLink}
-            style={tw`mt-4 items-center rounded-xl bg-royal px-5 py-3`}
+            accessibilityRole="button"
+            accessibilityLabel="Enviar enlace mágico al email"
+            style={[tw`mt-4 items-center rounded-xl px-5 py-3`, {
+              backgroundColor: theme.colors.brand[600],
+              opacity: loading || !emailValid ? 0.6 : 1,
+            }]}
           >
             {loading ? <ActivityIndicator color="#fff" /> : <Text style={tw`text-white font-semibold`}>Enviar enlace mágico</Text>}
           </Pressable>
@@ -117,7 +139,12 @@ export default function EmailAuthScreen() {
           <Pressable
             disabled={loading || !emailValid || (!isRegister && !password) || (!!passwordError)}
             onPress={submitPasswordFlow}
-            style={tw`mt-3 items-center rounded-xl bg-accent px-5 py-3`}
+            accessibilityRole="button"
+            accessibilityLabel={isRegister ? 'Crear cuenta' : 'Entrar con contraseña'}
+            style={[tw`mt-3 items-center rounded-xl px-5 py-3`, {
+              backgroundColor: theme.colors.brand[500],
+              opacity: loading || !emailValid || (!isRegister && !password) || (!!passwordError) ? 0.6 : 1,
+            }]}
           >
             {loading ? (
               <ActivityIndicator color="#fff" />
@@ -126,15 +153,15 @@ export default function EmailAuthScreen() {
             )}
           </Pressable>
 
-          <Pressable onPress={() => setIsRegister((v) => !v)} style={tw`mt-2 items-center`}>
-            <Text style={tw`text-navy text-sm`}>
+          <Pressable onPress={() => setIsRegister((v) => !v)} style={tw`mt-2 items-center`} accessibilityRole="button">
+            <Text style={[tw`text-sm`, { color: theme.colors.mut }]}>
               {isRegister ? '¿Ya tienes cuenta? Inicia sesión' : '¿No tienes cuenta? Crear una >'}
             </Text>
           </Pressable>
 
           {alert && (
             <View style={[tw`mt-4 rounded-xl px-4 py-3`, { backgroundColor: alert.type === 'error' ? '#FDECEC' : '#E8F2FF' }]}>
-              <Text style={[tw`text-center`, alert.type === 'error' ? tw`text-accent` : tw`text-royal`]}>{alert.text}</Text>
+              <Text style={[tw`text-center`, { color: alert.type === 'error' ? '#dc2626' : theme.colors.brand[600] }]}>{alert.text}</Text>
             </View>
           )}
         </View>

--- a/app/(auth)/welcome.tsx
+++ b/app/(auth)/welcome.tsx
@@ -2,17 +2,18 @@
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import tw from '@/lib/tw';
+import { theme } from '@/lib/theme';
 
 export default function Welcome() {
   const router = useRouter();
   return (
-    <View style={tw`flex-1 items-center justify-center bg-light px-6`}>
-      <Text style={tw`text-primary text-4xl font-extrabold`}>PrepAI English</Text>
-      <Text style={tw`text-royal mt-2`}>Bienvenido</Text>
+    <View style={[tw`flex-1 items-center justify-center px-6`, { backgroundColor: theme.colors.bg }]}>
+      <Text style={[tw`text-4xl font-extrabold`, { color: theme.colors.text }]}>PrepAI English</Text>
+      <Text style={[tw`mt-2`, { color: theme.colors.brand[600] }]}>Bienvenido</Text>
 
       <Pressable
         onPress={() => router.push('/(auth)/login' as any)}
-        style={tw`mt-8 px-6 py-3 rounded-xl bg-accent`}
+        style={[tw`mt-8 px-6 py-3 rounded-xl`, { backgroundColor: theme.colors.brand[500] }]}
       >
         <Text style={tw`text-white font-semibold`}>Iniciar sesión</Text>
       </Pressable>

--- a/app/(tabs)/exams.tsx
+++ b/app/(tabs)/exams.tsx
@@ -1,7 +1,7 @@
 import { View, Text } from "react-native";
 import { useRouter } from "expo-router";
 import { getExam } from "@/lib/exams";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import tw from '@/lib/tw';
 import { Button } from '@/components/ui/Button';
 import Container from '@/components/layout/Container';
@@ -9,12 +9,23 @@ import Heading from '@/components/ui/Heading';
 import TextMuted from '@/components/ui/TextMuted';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useToast } from '@/providers/Toast';
+import ActionCard from '@/components/ui/ActionCard';
+import Sheet from '@/components/ui/Sheet';
 
 export default function ExamsScreen() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const toast = useToast();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [pending, setPending] = useState<null | { title: string; sections: string[] }>(null);
+
+  const options = useMemo(() => ([
+    { title: 'Mock B2 completo', icon: 'document-text' as const, sections: ['Reading', 'Use of English', 'Listening'] },
+    { title: 'Solo Listening', icon: 'volume-high' as const, sections: ['Listening'] },
+    { title: 'Solo Reading', icon: 'book' as const, sections: ['Reading', 'Use of English'] },
+  ]), []);
+
   return (
     <Container>
       <Heading>Simulacros</Heading>
@@ -28,6 +39,46 @@ export default function ExamsScreen() {
           <View style={tw`mt-2`}><Skeleton height={18} /></View>
         </View>
       ) : null}
+
+      <View style={tw`mt-4 flex-row flex-wrap gap-3`}>
+        {options.map((opt) => (
+          <View key={opt.title} style={{ flexBasis: '100%', maxWidth: '100%' }}>
+            <ActionCard
+              small
+              title={opt.title}
+              icon={opt.icon}
+              tone="primary"
+              onPress={() => { setPending({ title: opt.title, sections: opt.sections }); setSheetOpen(true); }}
+            />
+          </View>
+        ))}
+      </View>
+
+      <Sheet visible={sheetOpen} title={pending?.title} onClose={() => setSheetOpen(false)}>
+        <Text style={tw`mb-2`}>Descripción breve del mock:</Text>
+        <TextMuted>Duración estimada: 45–60 min • Secciones: {pending?.sections.join(', ')}</TextMuted>
+        <View style={tw`mt-4 flex-row gap-3`}>
+          <Button
+            title={loading ? 'Generando...' : 'Comenzar'}
+            onPress={async () => {
+              if (!pending) return;
+              setLoading(true); setError(null);
+              try {
+                const exam = await getExam({ level: 'B2', sections: pending.sections });
+                try { toast.success('Examen generado'); } catch {}
+                setSheetOpen(false);
+                router.push({ pathname: "/exam/[id]" as any, params: { id: exam.id, data: JSON.stringify(exam) } } as any);
+              } catch (e: any) {
+                setError(e?.message || 'No se pudo generar el examen');
+                try { toast.error('No se pudo generar el examen'); } catch {}
+              } finally {
+                setLoading(false);
+              }
+            }}
+          />
+          <Button title="Cancelar" onPress={() => setSheetOpen(false)} />
+        </View>
+      </Sheet>
 
       <Button
         title={loading ? 'Generando...' : 'Generar Mock B2'}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,31 +1,109 @@
-import { View, Text } from "react-native";
+import { View, Text, Pressable } from "react-native";
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from "expo-router";
 import * as Speech from 'expo-speech';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import tw from '@/lib/tw';
-import { Button } from '@/components/ui/Button';
-import { Card } from '@/components/ui/Card';
 import Container from '@/components/layout/Container';
 import Heading from '@/components/ui/Heading';
 import TextMuted from '@/components/ui/TextMuted';
+import ActionCard from '@/components/ui/ActionCard';
+import StatPill from '@/components/ui/StatPill';
+import { useAuth } from '@/providers/AuthProvider';
+import { listMyAttempts } from '@/lib/db';
+import { getAttempts, type Attempt } from '@/lib/storage';
+import { computePointsFromAttempts, levelFromPoints } from '@/lib/gamify';
 
 export default function Home() {
   const router = useRouter();
+  const { session } = useAuth();
+  const [attempts, setAttempts] = useState<Attempt[]>([]);
+  const [challengeDone, setChallengeDone] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (session?.user && process.env.EXPO_PUBLIC_USE_SUPABASE === 'true') {
+          const cloud = await listMyAttempts();
+          const converted: Attempt[] = cloud.map(a => ({
+            id: a.id,
+            examId: a.exam_id || undefined,
+            title: (a.exam_snapshot as any)?.title || 'Examen',
+            level: (a.exam_snapshot as any)?.level || 'N/A',
+            createdAt: new Date(a.started_at).getTime(),
+            finishedAt: a.finished_at ? new Date(a.finished_at).getTime() : undefined,
+            score: a.score ? Number(a.score) : undefined,
+          }));
+          setAttempts(converted);
+        } else {
+          setAttempts(await getAttempts());
+        }
+      } catch {
+        setAttempts(await getAttempts());
+      }
+      const today = new Date().toISOString().slice(0,10);
+      const chk = await AsyncStorage.getItem(`challenge:${today}`);
+      setChallengeDone(chk === 'true');
+    })();
+  }, [session]);
+
+  const stats = useMemo(() => {
+    const total = attempts.length;
+    const scores = attempts.map(a => a.score ?? null).filter((x): x is number => typeof x === 'number');
+    const avg = scores.length ? Math.round(scores.reduce((s, v) => s + v, 0) / scores.length) : null;
+    const last = scores.length ? scores[scores.length - 1] : null;
+    const points = computePointsFromAttempts(attempts);
+    const level = levelFromPoints(points);
+    return { total, avg, last, points, level };
+  }, [attempts]);
+
   return (
     <Container>
       <Heading>PrepAI English</Heading>
-      <TextMuted>Mock exams powered by AI</TextMuted>
+      <TextMuted>Mejora tu nivel con simulacros y práctica guiada</TextMuted>
 
-      <Button title="Empezar un simulacro" onPress={() => router.push('/(tabs)/exams' as any)} style={tw`mt-2`} />
+      <View style={tw`mt-4 gap-4`}>
+        <ActionCard
+          title="Empezar simulacro"
+          subtitle="Simulacro de examen completo (B2). Pon a prueba tu nivel ahora"
+          icon="school"
+          tone="primary"
+          onPress={() => router.push('/(tabs)/exams' as any)}
+        />
+        <ActionCard
+          title="Probar Listening (TTS)"
+          icon="volume-high"
+          tone="info"
+          onPress={() => Speech.speak('Welcome to PrepAI English. This is a sample listening prompt.', { language: 'en-US' })}
+        />
+        <ActionCard
+          title="Practicar Speaking"
+          icon="mic"
+          tone="success"
+          onPress={() => router.push('/practice/speaking' as any)}
+        />
+      </View>
 
-      <Button
-        title="Probar Listening (TTS)"
-        onPress={() =>
-          Speech.speak('Welcome to PrepAI English. This is a sample listening prompt.', { language: 'en-US' })
-        }
-        style={[tw`mt-3`, { backgroundColor: '#3646ff' }]}
-      />
+      <View style={tw`mt-5 flex-row flex-wrap gap-2`}>
+        <StatPill label="Has completado" value={String(stats.total)} icon="checkmark-done" />
+        <StatPill label="Media" value={stats.avg != null ? `${stats.avg}%` : '—'} icon="trending-up" />
+        <StatPill label="Último" value={stats.last != null ? `${stats.last}%` : '—'} icon="speedometer" />
+        <StatPill label="Tus puntos" value={String(stats.points)} icon="trophy" />
+        <StatPill label="Nivel" value={stats.level} icon="ribbon" />
+      </View>
 
-      <Button title="Ir a Speaking" onPress={() => router.push('/practice/speaking' as any)} style={[tw`mt-3`, { backgroundColor: '#000' }]} />
+      <Pressable
+        accessibilityRole="button"
+        onPress={async () => {
+          const today = new Date().toISOString().slice(0,10);
+          await AsyncStorage.setItem(`challenge:${today}`, 'true');
+          setChallengeDone(true);
+        }}
+        style={tw`mt-5 rounded-2xl border px-4 py-3`}
+      >
+        <Text style={tw`font-semibold`}>Reto de hoy: Completa un Listening</Text>
+        <TextMuted>{challengeDone ? '¡Completado! ✅' : 'Marca como completado cuando lo termines.'}</TextMuted>
+      </Pressable>
     </Container>
   );
 }

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -8,11 +8,16 @@ import TextMuted from '@/components/ui/TextMuted';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useEffect, useState } from 'react';
 import { Card } from '@/components/ui/Card';
+import { getDefaultLevel } from '@/lib/prefs';
+import type { ExamLevel } from '@/types/level';
+import { useRouter } from 'expo-router';
 
 export default function SettingsScreen() {
   const { user, signOut } = useAuth();
+  const router = useRouter();
   const [dark, setDark] = useState(false);
   const [useCloud, setUseCloud] = useState(false);
+  const [defaultLevel, setDefaultLevelState] = useState<ExamLevel | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -21,6 +26,8 @@ export default function SettingsScreen() {
         setDark(pref === 'dark');
         const cloud = await AsyncStorage.getItem('dev:cloudExam');
         setUseCloud(cloud == null ? true : cloud === 'true');
+        const lvl = await getDefaultLevel();
+        setDefaultLevelState(lvl);
       } catch {}
     })();
   }, []);
@@ -69,6 +76,15 @@ export default function SettingsScreen() {
           </View>
         </Card>
       ) : null}
+
+      <Card style={tw`mt-4 p-4`}>
+        <Text style={tw`font-semibold`}>Preferencias</Text>
+        <View style={tw`mt-3`}>
+          <Text style={tw`font-medium`}>Nivel de examen por defecto: <Text style={tw`font-semibold`}>{defaultLevel ?? 'B2'}</Text></Text>
+          <TextMuted>Puedes cambiarlo cuando quieras.</TextMuted>
+          <Button title="Cambiar nivel" onPress={() => router.push('/onboarding/level?edit=true' as any)} style={tw`mt-3`} />
+        </View>
+      </Card>
 
       <Card style={tw`mt-4 p-4`}>
         <Text style={tw`font-semibold`}>Cuenta</Text>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -7,6 +7,7 @@ import Heading from '@/components/ui/Heading';
 import TextMuted from '@/components/ui/TextMuted';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useEffect, useState } from 'react';
+import { Card } from '@/components/ui/Card';
 
 export default function SettingsScreen() {
   const { user, signOut } = useAuth();
@@ -45,19 +46,34 @@ export default function SettingsScreen() {
       <Heading>Ajustes</Heading>
       <TextMuted>{user?.email}</TextMuted>
 
-      <View style={tw`mt-4 flex-row items-center justify-between`}>
-        <Text style={tw`font-medium`}>Modo oscuro (beta)</Text>
-        <Switch value={dark} onValueChange={toggleTheme} />
-      </View>
+      <Card style={tw`mt-4 p-4`}>
+        <Text style={tw`font-semibold`}>Apariencia</Text>
+        <View style={tw`mt-3 flex-row items-center justify-between`}>
+          <View style={tw`flex-1 pr-3`}>
+            <Text style={tw`font-medium`}>Modo oscuro (beta)</Text>
+            <TextMuted>Interfaz con fondo oscuro. Puede requerir recargar.</TextMuted>
+          </View>
+          <Switch value={dark} onValueChange={toggleTheme} />
+        </View>
+      </Card>
 
       {process.env.EXPO_PUBLIC_USE_SUPABASE === 'true' ? (
-        <View style={tw`mt-4 flex-row items-center justify-between`}>
-          <Text style={tw`font-medium`}>Usar nube para generar exámenes (dev)\n<TextMuted>(requiere .env EXPO_PUBLIC_USE_SUPABASE=true)</TextMuted></Text>
-          <Switch value={useCloud} onValueChange={toggleCloud} />
-        </View>
+        <Card style={tw`mt-4 p-4`}>
+          <Text style={tw`font-semibold`}>Desarrollo</Text>
+          <View style={tw`mt-3 flex-row items-center justify-between`}>
+            <View style={tw`flex-1 pr-3`}>
+              <Text style={tw`font-medium`}>Usar nube para generar exámenes</Text>
+              <TextMuted>Requiere .env EXPO_PUBLIC_USE_SUPABASE=true</TextMuted>
+            </View>
+            <Switch value={useCloud} onValueChange={toggleCloud} />
+          </View>
+        </Card>
       ) : null}
 
-      <Button title="Cerrar sesión" onPress={signOut} style={[tw`mt-6`, { backgroundColor: '#ef4444' }]} />
+      <Card style={tw`mt-4 p-4`}>
+        <Text style={tw`font-semibold`}>Cuenta</Text>
+        <Button title="Cerrar sesión" onPress={signOut} style={[tw`mt-3`, { backgroundColor: '#ef4444' }]} />
+      </Card>
     </Container>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
 // app/_layout.tsx     ← raíz de la carpeta app
-import { Slot, useRouter, useSegments, Stack } from "expo-router";
+import { useRouter, useSegments, Stack } from "expo-router";
 // Cargar estilos web globales (procesado por el bundler web de Expo, no por Babel)
 import "./global.css";
 import tw from "@/lib/tw";
@@ -28,7 +28,8 @@ function RootNavigationGate() {
     }
   }, [segments, router, session, initializing]);
 
-  return <Slot />;
+  // Effect-only gate to redirect based on auth; do not render another navigator here.
+  return null;
 }
 
 export default function RootLayout() {

--- a/app/auth/callback.tsx
+++ b/app/auth/callback.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, ActivityIndicator } from 'react-native';
 import { useRouter } from 'expo-router';
 import * as Linking from 'expo-linking';
 import { supabase } from '@/lib/supabase';
 import tw from '@/lib/tw';
+import { theme } from '@/lib/theme';
 
 export default function AuthCallbackScreen() {
   const router = useRouter();
@@ -12,15 +13,25 @@ export default function AuthCallbackScreen() {
     (async () => {
       if (!url) return;
       const { queryParams } = Linking.parse(url);
-      const code = (queryParams?.code as string) || '';
-      if (code) await supabase.auth.exchangeCodeForSession(code as any);
+      const code =
+        (queryParams?.code as string) ||
+        (queryParams?.['code'] as string) ||
+        '';
+      try {
+        if (code) {
+          await supabase.auth.exchangeCodeForSession(code as any);
+        }
+      } catch (e) {
+        console.warn('[auth/callback] exchangeCodeForSession error', e);
+      }
       router.replace('/(tabs)');
     })();
   }, [router, url]);
 
   return (
-    <View style={tw`flex-1 items-center justify-center bg-light`}>
-      <Text style={tw`text-primary text-xl font-semibold`}>Autenticando…</Text>
+    <View style={[tw`flex-1 items-center justify-center`, { backgroundColor: theme.colors.bg }]}>
+      <ActivityIndicator color={theme.colors.brand[600]} />
+      <Text style={[tw`mt-3 text-xl font-semibold`, { color: theme.colors.text }]}>Autenticando…</Text>
     </View>
   );
 }

--- a/app/onboarding/level.tsx
+++ b/app/onboarding/level.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react';
+import { View, Text, Pressable, Alert } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import tw from '@/lib/tw';
+import Container from '@/components/layout/Container';
+import Heading from '@/components/ui/Heading';
+import TextMuted from '@/components/ui/TextMuted';
+import ActionCard from '@/components/ui/ActionCard';
+import { LEVELS, type ExamLevel } from '@/types/level';
+import { setDefaultLevel } from '@/lib/prefs';
+import { updateDefaultLevel } from '@/lib/db';
+import { useAuth } from '@/providers/AuthProvider';
+import { useToast } from '@/providers/Toast';
+
+const DESCRIPTIONS: Record<ExamLevel, { title: string; desc: string; icon: any }> = {
+  B1: { title: 'B1', desc: 'Intermedio. Pensado para tareas cotidianas. Aprobado típico: ~60–70%.', icon: 'school' },
+  B2: { title: 'B2', desc: 'Intermedio-alto. Comprensión de textos complejos. Aprobado típico: ~60–70%.', icon: 'book' },
+  C1: { title: 'C1', desc: 'Avanzado. Uso flexible del idioma en contextos académicos/profesionales.', icon: 'trophy' },
+  C2: { title: 'C2', desc: 'Dominio. Comprensión total de matices y precisión.', icon: 'medal' },
+};
+
+export default function OnboardingLevel() {
+  const router = useRouter();
+  const params = useLocalSearchParams();
+  const { session } = useAuth();
+  const toast = useToast();
+  const cards = useMemo(() => LEVELS.map(l => DESCRIPTIONS[l]), []);
+
+  const selectLevel = async (level: ExamLevel) => {
+    const apply = async () => {
+      try {
+        await setDefaultLevel(level);
+        if (session && process.env.EXPO_PUBLIC_USE_SUPABASE === 'true') {
+          try { await updateDefaultLevel(level); } catch {}
+        }
+        try { toast.success('Nivel guardado'); } catch {}
+      } catch {}
+      router.replace('/(tabs)');
+    };
+    const rawEdit = (params as any)?.edit as string | string[] | undefined;
+    const isEdit = Array.isArray(rawEdit) ? rawEdit.includes('true') : rawEdit === 'true';
+    if (isEdit) {
+      Alert.alert(
+        'Cambiar nivel',
+        'Cambiar el nivel afectará a los simulacros que se generen y a las recomendaciones.',
+        [
+          { text: 'Cancelar', style: 'cancel' },
+          { text: 'Confirmar', style: 'destructive', onPress: apply },
+        ]
+      );
+      return;
+    }
+    await apply();
+  };
+
+  return (
+    <Container>
+      <Heading>Selecciona tu nivel</Heading>
+      <TextMuted>Podrás cambiarlo en Ajustes</TextMuted>
+
+      <View style={tw`mt-4 gap-3`}>
+        {cards.map((c) => (
+          <ActionCard
+            key={c.title}
+            title={c.title}
+            subtitle={c.desc}
+            icon={c.icon}
+            tone="primary"
+            onPress={() => selectLevel(c.title as ExamLevel)}
+          />
+        ))}
+      </View>
+
+      <Pressable onPress={() => router.replace('/(tabs)')} accessibilityRole="button" style={tw`mt-5`}>
+        <Text style={tw`text-center underline`}>Podrás cambiarlo en Ajustes</Text>
+      </Pressable>
+    </Container>
+  );
+}

--- a/components/AuthCard.tsx
+++ b/components/AuthCard.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from 'react-native';
 import { ExternalLink } from '@/components/ExternalLink';
 import tw from '@/lib/tw';
+import { theme } from '@/lib/theme';
 
 type Props = {
   title: string;
@@ -13,8 +14,8 @@ export default function AuthCard({ title, subtitle, children, footer }: Props) {
   return (
     <View style={[tw`w-full rounded-2xl bg-white p-8`, { maxWidth: 420, borderWidth: 1, borderColor: '#E5E7EB' }]}>
       <View style={tw`items-center`}>
-        <Text style={tw`text-3xl font-extrabold text-center text-primary`}>{title}</Text>
-        {subtitle ? <Text style={tw`mt-2 text-center text-royal`}>{subtitle}</Text> : null}
+        <Text style={[tw`text-3xl font-extrabold text-center`, { color: theme.colors.text }]}>{title}</Text>
+        {subtitle ? <Text style={[tw`mt-2 text-center`, { color: theme.colors.brand[600] }]}>{subtitle}</Text> : null}
       </View>
       <View style={tw`mt-6`}>{children}</View>
       <View style={tw`mt-6 items-center gap-2`}>

--- a/components/ui/ActionCard.tsx
+++ b/components/ui/ActionCard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import tw from '@/lib/tw';
+import { theme } from '@/lib/theme';
+
+export type ActionCardProps = {
+  title: string;
+  subtitle?: string;
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  onPress?: () => void;
+  tone?: 'primary' | 'success' | 'info' | 'neutral';
+  small?: boolean;
+};
+
+const tones: Record<NonNullable<ActionCardProps['tone']>, { bg: string; fg: string }> = {
+  primary: { bg: theme.colors.brand[600], fg: '#ffffff' }, // #1d4ed8
+  success: { bg: '#16a34a', fg: '#ffffff' },
+  info: { bg: theme.colors.brand[500], fg: '#ffffff' }, // #2563eb
+  neutral: { bg: '#64748b', fg: '#ffffff' },
+};
+
+export function ActionCard({ title, subtitle, icon, onPress, tone = 'neutral', small }: ActionCardProps) {
+  const c = tones[tone];
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [
+        tw`w-full rounded-2xl`,
+        { minHeight: small ? 56 : 72, outlineStyle: 'auto' as any },
+        { backgroundColor: '#ffffff', borderColor: theme.colors.border, borderWidth: 1 },
+        { shadowColor: '#000', shadowOpacity: 0.06, shadowRadius: 8, shadowOffset: { width: 0, height: 4 } },
+        pressed ? { opacity: 0.9 } : null,
+      ]}
+    >
+      <View style={tw`flex-row items-center gap-4 p-4`}>
+        <View
+          style={[tw`items-center justify-center rounded-2xl`, { width: small ? 36 : 44, height: small ? 36 : 44, backgroundColor: c.bg }]}
+        >
+          <Ionicons name={icon} size={small ? 18 : 22} color={c.fg} />
+        </View>
+        <View style={tw`flex-1`}>
+          <Text style={[tw`font-semibold`, { fontSize: small ? 16 : 18, color: theme.colors.text }]}>{title}</Text>
+          {subtitle ? (
+            <Text style={[tw`mt-1`, { color: theme.colors.mut, fontSize: small ? 12 : 13 }]}>{subtitle}</Text>
+          ) : null}
+        </View>
+        <Ionicons name="chevron-forward" size={20} color={theme.colors.mut} />
+      </View>
+    </Pressable>
+  );
+}
+
+export default ActionCard;

--- a/components/ui/BadgeCard.tsx
+++ b/components/ui/BadgeCard.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import tw from '@/lib/tw';
+import { theme } from '@/lib/theme';
+
+export type BadgeCardProps = {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  title: string;
+};
+
+export default function BadgeCard({ icon, title }: BadgeCardProps) {
+  return (
+    <View style={[tw`flex-row items-center gap-3 rounded-2xl p-4`, { backgroundColor: '#fff', borderColor: theme.colors.border, borderWidth: 1 }]}>
+      <View style={[tw`items-center justify-center rounded-xl`, { width: 36, height: 36, backgroundColor: theme.colors.brand[500] }]}>
+        <Ionicons name={icon} size={18} color="#fff" />
+      </View>
+      <Text style={[tw`font-semibold`, { color: theme.colors.text }]}>{title}</Text>
+    </View>
+  );
+}

--- a/components/ui/Sheet.tsx
+++ b/components/ui/Sheet.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Modal, Pressable, Text, View } from 'react-native';
+import tw from '@/lib/tw';
+import { theme } from '@/lib/theme';
+
+export type SheetProps = {
+  visible: boolean;
+  title?: string;
+  onClose?: () => void;
+  children?: React.ReactNode;
+};
+
+export default function Sheet({ visible, title, onClose, children }: SheetProps) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={[tw`flex-1 items-center justify-center`, { backgroundColor: 'rgba(0,0,0,0.4)' }]}>        
+        <Pressable style={tw`absolute inset-0`} onPress={onClose} accessibilityRole="button" />
+        <View
+          style={[
+            tw`w-11/12 rounded-2xl`,
+            { maxWidth: 520, backgroundColor: '#fff', borderWidth: 1, borderColor: theme.colors.border },
+          ]}
+        >
+          {title ? (
+            <View style={tw`border-b px-5 py-4`}>
+              <Text style={[tw`font-semibold`, { color: theme.colors.text }]}>{title}</Text>
+            </View>
+          ) : null}
+          <View style={tw`p-5`}>{children}</View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/components/ui/Sparkline.tsx
+++ b/components/ui/Sparkline.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Svg, Polyline } from 'react-native-svg';
+import { theme } from '@/lib/theme';
+
+export type SparklineProps = {
+  data: number[];
+  width?: number;
+  height?: number;
+  color?: string;
+};
+
+export default function Sparkline({ data, width = 280, height = 64, color = theme.colors.brand[600] }: SparklineProps) {
+  if (!Array.isArray(data) || data.length === 0) {
+    // Fallback tiny bars with Views
+    return (
+      <View style={{ width, height, flexDirection: 'row', alignItems: 'flex-end', gap: 2 }}>
+        {new Array(8).fill(0).map((_, i) => (
+          <View key={i} style={{ width: Math.max(2, width / 20), height: Math.max(4, (i + 2) * 3), backgroundColor: color, borderRadius: 2 }} />
+        ))}
+      </View>
+    );
+  }
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const stepX = width / Math.max(1, data.length - 1);
+
+  const points = data
+    .map((v, i) => {
+      const x = i * stepX;
+      const y = height - ((v - min) / range) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <Svg width={width} height={height}>
+      <Polyline points={points} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />
+    </Svg>
+  );
+}

--- a/components/ui/StatPill.tsx
+++ b/components/ui/StatPill.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import tw from '@/lib/tw';
+import { theme } from '@/lib/theme';
+
+export type StatPillProps = {
+  label: string;
+  value: string;
+  icon?: React.ComponentProps<typeof Ionicons>['name'];
+};
+
+export default function StatPill({ label, value, icon }: StatPillProps) {
+  return (
+    <View
+      style={[
+        tw`flex-row items-center gap-2 rounded-full px-3 py-2`,
+        { backgroundColor: '#ffffff', borderColor: theme.colors.border, borderWidth: 1 },
+      ]}
+    >
+      {icon ? <Ionicons name={icon} size={14} color={theme.colors.mut} /> : null}
+      <Text style={[tw`text-xs`, { color: theme.colors.mut }]}>{label}</Text>
+      <Text style={[tw`text-xs font-semibold`, { color: theme.colors.text }]}>{value}</Text>
+    </View>
+  );
+}

--- a/lib/gamify.ts
+++ b/lib/gamify.ts
@@ -1,0 +1,20 @@
+import type { Attempt } from '@/lib/storage';
+
+export function computePointsFromAttempts(attempts: Attempt[]): number {
+  if (!Array.isArray(attempts) || attempts.length === 0) return 0;
+  return attempts.reduce((sum, a) => {
+    const base = 10; // por simulacro
+    const score = typeof a.score === 'number' ? a.score : 0;
+    const bonus = Math.floor(score / 10); // 1 punto cada 10% de score
+    return sum + base + bonus;
+  }, 0);
+}
+
+export function levelFromPoints(n: number): 'A1'|'A2'|'B1'|'B2'|'C1'|'C2' {
+  if (n <= 20) return 'A1';
+  if (n <= 50) return 'A2';
+  if (n <= 120) return 'B1';
+  if (n <= 200) return 'B2';
+  if (n <= 300) return 'C1';
+  return 'C2';
+}

--- a/lib/prefs.ts
+++ b/lib/prefs.ts
@@ -1,0 +1,12 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { ExamLevel } from '@/types/level';
+
+const KEY = 'pref:defaultExamLevel';
+
+export async function getDefaultLevel(): Promise<ExamLevel | null> {
+  const v = await AsyncStorage.getItem(KEY);
+  return (v === 'B1' || v === 'B2' || v === 'C1' || v === 'C2') ? (v as ExamLevel) : null;
+}
+export async function setDefaultLevel(level: ExamLevel) {
+  await AsyncStorage.setItem(KEY, level);
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3,6 +3,7 @@ create table if not exists public.profiles (
   id uuid primary key references auth.users (id) on delete cascade,
   email text unique,
   display_name text,
+  default_level text check (default_level in ('B1','B2','C1','C2')),
   created_at timestamptz default now()
 );
 alter table public.profiles enable row level security;

--- a/types/level.ts
+++ b/types/level.ts
@@ -1,0 +1,2 @@
+export type ExamLevel = 'B1' | 'B2' | 'C1' | 'C2';
+export const LEVELS: ExamLevel[] = ['B1', 'B2', 'C1', 'C2'];


### PR DESCRIPTION
Implementa onboarding para seleccionar el nivel por defecto (B1/B2/C1/C2), persistencia local y en Supabase, gate de navegación, ver/cambiar nivel en Ajustes y uso del nivel por defecto en la generación de exámenes. Highlights:
types/level.ts: ExamLevel + LEVELS
lib/prefs.ts: get/set default level (AsyncStorage)
lib/db.ts: updateDefaultLevel + getProfileDefaultLevel
providers/AuthProvider.tsx: sync cloud/local de default_level al cambiar sesión
app/onboarding/level.tsx: pantalla de onboarding con confirmación en modo edición (?edit=true)
app/_layout.tsx: LevelGate (omite (auth))
app/(tabs)/settings.tsx: mostrar/cambiar nivel
lib/exams.ts: fallback al nivel por defecto (B2)
supabase/schema.sql: profiles.default_level con check constraint
README.md: migración + documentación de onboarding
Validación:
npm run lint: OK
npm run typecheck: OK
npm run build:web: OK